### PR TITLE
Add .gitignore rules for IDE files and temp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Ignore IDE configuration files
+.idea/
+
+# Ignore chromedriver binary
+chromedriver
+
+# Ignore Python bytecode
+*.py[cod]
+__pycache__/
+
+# Ignore temporary files
+*.log
+*.tmp
+*~
+*.swp
+.DS_Store
+


### PR DESCRIPTION
## Summary
- add a repo-wide `.gitignore` to exclude IDE configs, `chromedriver`, python bytecode and temporary files

## Testing
- `git status --short`
